### PR TITLE
Support secondary result collection type

### DIFF
--- a/bluelight/scripts/plugin/xnat.js
+++ b/bluelight/scripts/plugin/xnat.js
@@ -31,10 +31,14 @@ function readJson_xnat(url) {
     request.onload = function () {
         var response = request.response;
         for (var i = 0; i < response["ResultSet"]["Result"].length; i++) {
-            if (response["ResultSet"]["Result"][i]["collection"] == "DICOM" || response["ResultSet"]["Result"][i]["collection"] == "DCM") {
+
+            let supportedImages = ["DICOM", "DCM", "secondary"];
+            if (supportedImages.includes(response["ResultSet"]["Result"][i]["collection"])) {
                 var uri = window.location.protocol + "//" + window.location.hostname + ":" + window.location.port + response["ResultSet"]["Result"][i]["URI"];
                 url = "wadouri:" + uri;
                 series = loadAndViewImage(url);
+            } else {
+                console.error("Not supported collection type");
             }
         }
     }


### PR DESCRIPTION
On XNAT when you want other DICOM images you need to include the type "secondary" for OT modality.