### PR TITLE
fix: cannot read RTSS when any 30060039 missing 30060040

### DIFF
--- a/bluelight/scripts/readsome.js
+++ b/bluelight/scripts/readsome.js
@@ -188,6 +188,12 @@ function readDicomRTSS(byteArray, dataSet, patientmark) {
       var colorStr = ("" + dataSet.elements.x30060039.items[i].dataSet.string('x3006002a')).split("\\");
       var color;
       if (colorStr) color = "rgb(" + parseInt(colorStr[0]) + ", " + parseInt(colorStr[1]) + ", " + parseInt(colorStr[2]) + ")";
+
+
+      if (!Object.prototype.hasOwnProperty.call(dataSet.elements.x30060039.items[i].dataSet.elements, "x30060040")) {
+        continue;
+      }
+
       for (var j in dataSet.elements.x30060039.items[i].dataSet.elements.x30060040.items) {
         for (var k in dataSet.elements.x30060039.items[i].dataSet.elements.x30060040.items[j].dataSet.elements.x30060016.items) {
           var dcm = {};


### PR DESCRIPTION
# Problems
- When I read some RTSS, the BlueLight got Uncaught TypeError: Cannot read properties of undefined (reading 'items')
    at readDicomRTSS (readsome.js:191:84)

![image](https://user-images.githubusercontent.com/49154622/230601247-aaea0fa6-1065-4b11-93b6-561f7dce2e84.png)
- The RTSS' DICOM Tree (The first `ROI Contour 1` miss `Contour Sequence`(3006, 0040))
![image](https://user-images.githubusercontent.com/49154622/230603332-c187c24d-926e-4de4-b5eb-d23d1de8b1c2.png)

# Solutions
- Because of RTSS that I test don't have 30060040 in the first `ROI Contour Sequence`
- So, I add the condition to check the `ROI Contour` field is exist
- If not exist, do continue

# Test detail
- Same series in `Problems` section
![image](https://user-images.githubusercontent.com/49154622/230601522-4e457ea3-9a71-488a-8b17-5aad348ca79f.png)

