### PR TITLE
fix: display color is broken

### DIFF
--- a/bluelight/scripts/viewer.js
+++ b/bluelight/scripts/viewer.js
@@ -460,58 +460,47 @@ function parseDicomWithoutImage(dataSet, imageId) {
     }
 }
 
-function loadDicomMutiFrame(image, imageId, viewportNum0) {
+function loadDicomMultiFrame(image, imageId, viewportNum0) {
     var dataSet = image.data;
     var Size = image.width * image.height;
+    var pixelData;
     var BitsAllocated = image.data.int16('x00280100');
+    if (BitsAllocated == 16) pixelData = new Int16Array(dataSet.byteArray.buffer, dataSet.elements.x7fe00010.dataOffset, dataSet.elements.x7fe00010.length / 2);
+    else if (BitsAllocated == 32) pixelData = new Int32Array(dataSet.byteArray.buffer, dataSet.elements.x7fe00010.dataOffset, dataSet.elements.x7fe00010.length / 4);
+    else if (BitsAllocated == 8) pixelData = new Int8Array(dataSet.byteArray.buffer, dataSet.elements.x7fe00010.dataOffset, dataSet.elements.x7fe00010.length / 1);
+    else pixelData = new Int16Array(dataSet.byteArray.buffer, dataSet.elements.x7fe00010.dataOffset, dataSet.elements.x7fe00010.length / 2);
+    if (!pixelData) return;
 
-    var frames = [];
-    var TotalFrames = image.data.intString('x00280008');
+    let frames = [];
+    let totalFrames = image.data.intString('x00280008');
 
-    if (image.data.string("x00020010") && image.data.string("x00020010").includes("1.2.840.10008.1.2.4")) {
-        for (var i = 0; i < dataSet.elements.x7fe00010.fragments.length; i++) {
-            var pixelData;
-            if (BitsAllocated == 16) pixelData = new Int16Array(dataSet.byteArray.buffer, dataSet.elements.x7fe00010.fragments[i].position, dataSet.elements.x7fe00010.fragments[i].length / 2);
-            else if (BitsAllocated == 32) pixelData = new Int32Array(dataSet.byteArray.buffer, dataSet.elements.x7fe00010.fragments[i].position, dataSet.elements.x7fe00010.fragments[i].length / 4);
-            else if (BitsAllocated == 8) pixelData = new Int8Array(dataSet.byteArray.buffer, dataSet.elements.x7fe00010.fragments[i].position, dataSet.elements.x7fe00010.fragments[i].length / 1);
-            else pixelData = new Int16Array(dataSet.byteArray.buffer, dataSet.elements.x7fe00010.fragments[i].position, dataSet.elements.x7fe00010.length / 2);
-            if (!pixelData) return;
-
-            var NewpixelData = decodeImageFrame(cornerstoneWADOImageLoader.getImageFrame(imageId), image.data.string("x00020010"), pixelData, {
-                usePDFJS: false
-            }).pixelData;
-
-            if (NewpixelData) pixelData = NewpixelData;
-            frames.push(pixelData);
-        }
-    } else {
-        var pixelData;
-        if (BitsAllocated == 16) pixelData = new Int16Array(dataSet.byteArray.buffer, dataSet.elements.x7fe00010.dataOffset, dataSet.elements.x7fe00010.length / 2);
-        else if (BitsAllocated == 32) pixelData = new Int32Array(dataSet.byteArray.buffer, dataSet.elements.x7fe00010.dataOffset, dataSet.elements.x7fe00010.length / 4);
-        else if (BitsAllocated == 8) pixelData = new Int8Array(dataSet.byteArray.buffer, dataSet.elements.x7fe00010.dataOffset, dataSet.elements.x7fe00010.length / 1);
-        else pixelData = new Int16Array(dataSet.byteArray.buffer, dataSet.elements.x7fe00010.dataOffset, dataSet.elements.x7fe00010.length / 2);
-        if (!pixelData) return;
-
-        for (var i = 0; i < TotalFrames; i++) {
-            frames.push(pixelData.slice(Size * i, Size * i + Size));
-        }
+    for (let i = 0; i < totalFrames; i++) {
+        let imageFrameId = `${imageId}?frame=${i}`;
+        cornerstone.loadImage(imageFrameId).then((img) => {
+            frames.push(img.getPixelData());
+        });
     }
 
-    var DICOM_obj = {
-        study: image.data.string('x0020000d'),
-        series: image.data.string('x0020000e'),
-        sop: image.data.string('x00080018'),
-        instance: image.data.string('x00200013'),
-        imageId: imageId,
-        image: image,
-        pixelData: frames[0],//pixelData.slice(0, Size),
-        frames: frames,
-        patientId: image.data.string('x00100020')
-    };
-
-    loadUID(DICOM_obj);
-
-    parseDicom(image, DICOM_obj.frames[0], viewportNum0);
+    let checkFrameLoadedInterval = setInterval(() => {
+        if (frames.length === totalFrames) {
+            let DICOM_obj = {
+                study: image.data.string('x0020000d'),
+                series: image.data.string('x0020000e'),
+                sop: image.data.string('x00080018'),
+                instance: image.data.string('x00200013'),
+                imageId: imageId,
+                image: image,
+                pixelData: frames[0],//pixelData.slice(0, Size),
+                frames: frames,
+                patientId: image.data.string('x00100020')
+            };
+        
+            loadUID(DICOM_obj);
+        
+            parseDicom(image, DICOM_obj.frames[0], viewportNum0);
+            clearInterval(checkFrameLoadedInterval);
+        }
+    }, 200);
 }
 
 function parseDicom(image, pixelData, viewportNum0) {
@@ -832,7 +821,7 @@ function onlyLoadImage(imageId) {
                 usePDFJS: true
             }).then(function (image) {
                 if (image.data.intString("x00280008") > 1) {//muti frame
-                    loadDicomMutiFrame(image, image.imageId, viewportNum0);
+                    loadDicomMultiFrame(image, image.imageId, viewportNum0);
                 } else {
                     var DICOM_obj = {
                         study: image.data.string('x0020000d'),
@@ -874,7 +863,7 @@ function loadAndViewImage(imageId, viewportNum0, framesNumber) {
             }).then(function (image) {
 
                 if (image.data.intString("x00280008") > 1) {//muti frame
-                    loadDicomMutiFrame(image, image.imageId, viewportNum0);
+                    loadDicomMultiFrame(image, image.imageId, viewportNum0);
                 } else {
                     var DICOM_obj = {
                         study: image.data.string('x0020000d'),


### PR DESCRIPTION
# Problems
- I opened the image that I test previous, it's color is broken

## Current version (542f931)
![image](https://user-images.githubusercontent.com/49154622/237026590-a6b4ba09-86c5-4182-99f9-b460e241d24e.png)
![image](https://user-images.githubusercontent.com/49154622/237027779-572ba57c-278b-4307-95be-353992d442fe.png)


## Old version (6f50cd0)
![image](https://user-images.githubusercontent.com/49154622/237027575-98791ee8-b2e9-4835-9c98-cc9b2bb01b5e.png)
![image](https://user-images.githubusercontent.com/49154622/237027866-67bad46c-45b7-4d79-8079-c1cc36767505.png)


# Solutions
- I suspect that loadDicomMultiFrame did not correctly read the DICOM
- ⚠⚠ So, I reset the commit to e289dd4 and use the cornerstone's `loadImage` function instead of the original way

# Test detail
- image from: ftp://medical.nema.org/medical/dicom/Datasets/WG26/WG26Demo2020_PV/Diagnostics%5ERoche%5ETissue%20%5B0010%5D/20200731%20104639%20%5BSteiner%2040x%20z1%20Q%5D/Series%20001%20%5BSM%5D
- instance filename: 2.16.840.1.113995.3.110.3.0.10118.2000002.862753.2.dcm

https://user-images.githubusercontent.com/49154622/237030079-665a8123-27ef-49f8-8b11-ae56977178ab.mp4

- image from: https://github.com/cylab-tw/bluelight/issues/29#issuecomment-1532946020

https://user-images.githubusercontent.com/49154622/237030812-8859c48e-ce1a-42d4-a154-6416bf6c69f8.mp4

# 🛑 Please do more tests and reply to me if any bug present to improve this brilliant project