### PR TITLE
fix: maintain loading indicator until all DICOM images are loaded

### DIFF
--- a/bluelight/scripts/viewer.js
+++ b/bluelight/scripts/viewer.js
@@ -110,18 +110,23 @@ class LoadFileInBatches {
 
     static finishOne() {
         if (LoadFileInBatches.NumOfFetchs > 0) LoadFileInBatches.NumOfFetchs--;
+
+        // Only hide the status indicator when all fetches are complete and queue is empty
+        if (LoadFileInBatches.NumOfFetchs === 0 && LoadFileInBatches.queue.length === 0) {
+            hideDicomStatus();
+        }
     }
 }
 
 function wadorsLoader2(url, onlyload) {
     // Show loading status
     showDicomStatus("Loading images...");
-    
+
     var headers = {
-        'user-agent': 'Mozilla/4.0 MDN Example', 
+        'user-agent': 'Mozilla/4.0 MDN Example',
         'content-type': 'multipart/related; type=application/dicom;'
     }
-    
+
     var wadoToken = ConfigLog.WADO.token;
     for (var to = 0; to < Object.keys(wadoToken).length; to++) {
         if (wadoToken[Object.keys(wadoToken)[to]] != "")
@@ -129,28 +134,28 @@ function wadorsLoader2(url, onlyload) {
     }
 
     fetch(url, { headers })
-    .then(function(res) {
-        if (!res.ok) {
-            console.error("HTTP error:", res.status, res.statusText);
-            showDicomStatus("PACS error: " + res.status + " " + res.statusText, true);
-            throw new Error('HTTP error ' + res.status + ': ' + res.statusText);
-        }
-        return res.arrayBuffer();
-    })
-    .then(function(resBlob) {
-        let decodedBuffers = multipartDecode(resBlob);
-        for (let decodedBuf of decodedBuffers) {
-            loadDicomDataSet(decodedBuf, !(onlyload == true), url, false, 'mht');
-        }
-        hideDicomStatus();
-    })
-    .catch(function(error) {
-        console.error("Fetch error:", error);
-        showDicomStatus("PACS error: " + error.message, true);
-    })
-    .finally(function() {
-        LoadFileInBatches.finishOne();
-    });
+        .then(function (res) {
+            if (!res.ok) {
+                console.error("HTTP error:", res.status, res.statusText);
+                showDicomStatus("PACS error: " + res.status + " " + res.statusText, true);
+                throw new Error('HTTP error ' + res.status + ': ' + res.statusText);
+            }
+            return res.arrayBuffer();
+        })
+        .then(function (resBlob) {
+            let decodedBuffers = multipartDecode(resBlob);
+            for (let decodedBuf of decodedBuffers) {
+                loadDicomDataSet(decodedBuf, !(onlyload == true), url, false, 'mht');
+            }
+            // Removed hideDicomStatus() call from here
+        })
+        .catch(function (error) {
+            console.error("Fetch error:", error);
+            showDicomStatus("PACS error: " + error.message, true);
+        })
+        .finally(function () {
+            LoadFileInBatches.finishOne();
+        });
 }
 
 /**
@@ -547,12 +552,12 @@ function loadDicomDataSet(fileData, loadimage = true, url, fromLocal = false, fi
 function loadDICOMFromUrl(url, loadimage = true) {
     // Show loading status
     showDicomStatus("Loading images...");
-    
+
     var headers = {
-        'user-agent': 'Mozilla/4.0 MDN Example', 
+        'user-agent': 'Mozilla/4.0 MDN Example',
         'content-type': 'multipart/related; type=application/dicom;'
     }
-    
+
     var wadoToken = ConfigLog.WADO.token;
     for (var to = 0; to < Object.keys(wadoToken).length; to++) {
         if (wadoToken[Object.keys(wadoToken)[to]] != "")
@@ -560,25 +565,25 @@ function loadDICOMFromUrl(url, loadimage = true) {
     }
 
     fetch(url, { headers })
-    .then(function(res) {
-        if (!res.ok) {
-            console.error("HTTP error:", res.status, res.statusText);
-            showDicomStatus("PACS error: " + res.status + " " + res.statusText, true);
-            throw new Error('HTTP error ' + res.status + ': ' + res.statusText);
-        }
-        return res.arrayBuffer();
-    })
-    .then(function(oReq) {
-        loadDicomDataSet(oReq, loadimage == true, url, false);
-        hideDicomStatus();
-    })
-    .catch(function(error) {
-        console.error("Fetch error:", error);
-        showDicomStatus("PACS error: " + error.message, true);
-    })
-    .finally(function() {
-        LoadFileInBatches.finishOne();
-    });
+        .then(function (res) {
+            if (!res.ok) {
+                console.error("HTTP error:", res.status, res.statusText);
+                showDicomStatus("PACS error: " + res.status + " " + res.statusText, true);
+                throw new Error('HTTP error ' + res.status + ': ' + res.statusText);
+            }
+            return res.arrayBuffer();
+        })
+        .then(function (oReq) {
+            loadDicomDataSet(oReq, loadimage == true, url, false);
+            // Removed hideDicomStatus() call from here
+        })
+        .catch(function (error) {
+            console.error("Fetch error:", error);
+            showDicomStatus("PACS error: " + error.message, true);
+        })
+        .finally(function () {
+            LoadFileInBatches.finishOne();
+        });
 }
 
 // Add this near the top of onload.js if showDicomStatus isn't available
@@ -586,22 +591,30 @@ function showDicomStatus(message, isError = false) {
     console.log("Status update:", message, "isError:", isError);
     var statusDiv = document.getElementById('dicomStatusIndicator');
     if (statusDiv) {
-      if (isError) {
-        statusDiv.innerHTML = '<span style="color:#ff3333;font-weight:bold;">⚠️ ' + message + '</span>';
-        statusDiv.style.backgroundColor = 'rgba(50,0,0,0.85)';
-      } else {
-        statusDiv.innerHTML = '<span style="display:inline-block;width:12px;height:12px;border:2px solid #fff;border-radius:50%;border-top-color:transparent;animation:spin 1s linear infinite;margin-right:5px;"></span>' + message;
-        statusDiv.style.backgroundColor = 'rgba(0,0,0,0.85)';
-      }
-      if(!document.getElementById('spinner-style')){
-        var s=document.createElement('style');
-        s.id='spinner-style';
-        s.textContent='@keyframes spin{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}';
-        document.head.appendChild(s);
-      }
-      statusDiv.style.display = 'block';
+        if (isError) {
+            statusDiv.innerHTML = '<span style="color:#ff3333;font-weight:bold;">⚠️ ' + message + '</span>';
+            statusDiv.style.backgroundColor = 'rgba(50,0,0,0.85)';
+        } else {
+            statusDiv.innerHTML = '<span style="display:inline-block;width:12px;height:12px;border:2px solid #fff;border-radius:50%;border-top-color:transparent;animation:spin 1s linear infinite;margin-right:5px;"></span>' + message;
+            statusDiv.style.backgroundColor = 'rgba(0,0,0,0.85)';
+        }
+        if (!document.getElementById('spinner-style')) {
+            var s = document.createElement('style');
+            s.id = 'spinner-style';
+            s.textContent = '@keyframes spin{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}';
+            document.head.appendChild(s);
+        }
+        statusDiv.style.display = 'block';
     }
-  }
+}
+
+function hideDicomStatus() {
+    var statusDiv = getByid('dicomStatusIndicator');
+    if (statusDiv) {
+        statusDiv.style.display = 'none';
+        statusDiv.style.backgroundColor = 'rgba(0,0,0,0.7)'; // Reset background
+    }
+}
 
 function hideDicomStatus() {
     var statusDiv = getByid('dicomStatusIndicator');


### PR DESCRIPTION
Maintain Loading Indicator Until All DICOM Images Are Loaded

## Description
This PR fixes an issue where the "Loading images..." status indicator would disappear prematurely before all DICOM instances in a study were fully loaded. The indicator now stays visible throughout the entire loading process, providing users with continuous feedback until all images are available for viewing.

## Problem
Previously, the `hideDicomStatus()` function was being called after each individual DICOM instance was loaded, causing the loading indicator to flash or disappear entirely while the system was still processing remaining images. This created a confusing user experience where users couldn't tell if the loading process was still ongoing or had completed.

## Solution
- Removed `hideDicomStatus()` calls from individual loading functions (`wadorsLoader2` and `loadDICOMFromUrl`)
- Modified `LoadFileInBatches.finishOne()` to only hide the status indicator when all fetches are complete AND the queue is empty
- Ensured proper status display through the entire loading workflow

## Changes Made
- Refactored loading status management in `viewer.js`
- Added condition to only hide status when `NumOfFetchs === 0 && queue.length === 0`
- Maintained existing error display functionality

## Testing Performed
- Tested with studies containing multiple series and instances
- Verified loading indicator remains visible throughout the entire loading process
- Confirmed indicator correctly disappears when loading is genuinely complete
- Validated error messages still display properly when loading fails

## Screen Recording
https://github.com/user-attachments/assets/5e3c635a-f1a5-498e-bf8b-bbc9bae96e33

## Related Issues
Resolves issue with intermittent loading status display.