### PR TITLE
magnifier: zoom on mousemove only

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "liveServer.settings.port": 5501
-}

--- a/bluelight/scripts/newscript/zoom.js
+++ b/bluelight/scripts/newscript/zoom.js
@@ -84,42 +84,27 @@ function zoom() {
             set_BL_model.onchange = function () { return 0; };
         }
 
-        BlueLightMousedownList = [];
-        BlueLightMousedownList.push(function (e) {
-            let angle2point = rotateCalculation(e);
-            magnifierIng(angle2point[0], angle2point[1]);
-            if (MouseDownCheck) magnifierDiv.show();
-        });
-
         BlueLightMousemoveList = [];
         BlueLightMousemoveList.push(function (e) {
             if (rightMouseDown) scale_size(e, originalPoint_X, originalPoint_Y);
-            if (MouseDownCheck) {
-                magnifierDiv.show();
-                let angle2point = rotateCalculation(e);
-                magnifierIng(angle2point[0], angle2point[1]);
+            
+            magnifierDiv.show();
+            let angle2point = rotateCalculation(e);
+            magnifierIng(angle2point[0], angle2point[1]);
 
-                dgs = document.getElementById("magnifierDiv").style;
-                if (document.body.scrollTop && document.body.scrollTop != 0) {
-                    dbst = document.body.scrollTop;
-                    dbsl = document.body.scrollLeft;
-                }
-                else {
-                    dbst = getByTag("html")[0].scrollTop;
-                    dbsl = getByTag("html")[0].scrollLeft;
-                }
-                y = e.clientY; x = e.clientX;
-                if (!y || !x) { y = e.touches[0].clientY; x = e.touches[0].clientX; }
-                dgs.top = y + dbst + (-parseInt(magnifierCanvas.style.height) / 2) + "px";
-                dgs.left = x + dbsl + (-parseInt(magnifierCanvas.style.width) / 2) + "px";
+            dgs = document.getElementById("magnifierDiv").style;
+            if (document.body.scrollTop && document.body.scrollTop != 0) {
+                dbst = document.body.scrollTop;
+                dbsl = document.body.scrollLeft;
             }
-        });
-
-        BlueLightMouseupList = [];
-        BlueLightMouseupList.push(function (e) {
-            if (openMouseTool && rightMouseDown) displayMark();
-            magnifierDiv.hide();
-            if (openLink) displayAllRuler();
+            else {
+                dbst = getByTag("html")[0].scrollTop;
+                dbsl = getByTag("html")[0].scrollLeft;
+            }
+            y = e.clientY; x = e.clientX;
+            if (!y || !x) { y = e.touches[0].clientY; x = e.touches[0].clientX; }
+            dgs.top = y + dbst + (-parseInt(magnifierCanvas.style.height) / 2) + "px";
+            dgs.left = x + dbsl + (-parseInt(magnifierCanvas.style.width) / 2) + "px";
         });
 
         BlueLightTouchstartList = [];
@@ -127,17 +112,15 @@ function zoom() {
             magnifierDiv.show();
             let angle2point = rotateCalculation(e);
             [currX11, currY11] = angle2point[0];
-            magnifierIng(currX11, currY11);
+            magnifierIng(angle2point[0], angle2point[1]);
         });
 
         BlueLightTouchmoveList = [];
         BlueLightTouchmoveList.push(function (e, e2) {
             if ((getByid("DICOMTagsSelect").selected || getByid("AIMSelect").selected)) return;
-            if (TouchDownCheck == true && rightTouchDown == false) {
-                magnifierDiv.show();
-                let angle2point = rotateCalculation(e);
-                magnifierIng(angle2point[0], angle2point[1]);
-            }
+            magnifierDiv.show();
+            let angle2point = rotateCalculation(e);
+            magnifierIng(angle2point[0], angle2point[1]);
         });
 
         BlueLightTouchendList = [];


### PR DESCRIPTION
Update the magnifier to trigger zoom on mousemove alone, removing the need to hold down the mouse button.